### PR TITLE
Apis and rules

### DIFF
--- a/ios/ios_apis.go
+++ b/ios/ios_apis.go
@@ -1,0 +1,56 @@
+package ios
+
+import (
+	"regexp"
+	"strings"
+)
+
+type CodeAPI struct {
+	Desc string
+	Match Match
+}
+
+var CodeAPIs = []CodeAPI {
+	{
+		"Network Calls",
+		func(s string) bool {
+			r, _ := regexp.MatchString(`NSURL|CFStream|NSStream`, s)
+			return r
+		},
+	},
+	{
+		"Local File I/O Operations.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(
+				`Keychain|kSecAttrAccessibleWhenUnlocked|kSecAttrAccessibleAfterFirstUnlock|SecItemAdd|` + `
+				SecItemUpdate|NSDataWritingFileProtectionComplete`, s)
+			return r
+		},
+	},
+	{
+		"WebView Component",
+		func(s string) bool {
+			r, _ := regexp.MatchString("UIWebView", s)
+			return r
+		},
+	},
+	{
+		"Encryption API",
+		func(s string) bool {
+			r, _ := regexp.MatchString("RNEncryptor|RNDecryptor|AESCrypt", s)
+			return r
+		},
+	},
+	{
+		"Keychain Access",
+		func(s string) bool {
+			return strings.Contains(s, "PDKeychainBindings")
+		},
+	},
+	{
+		"WebView Load Request",
+		func(s string) bool {
+			return strings.Contains(s, "loadRequest") && strings.Contains(s, "webView")
+		},
+	},
+}

--- a/ios/ios_apis_test.go
+++ b/ios/ios_apis_test.go
@@ -1,0 +1,22 @@
+package ios
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestIosAPIs(t *testing.T) {
+	var errors strings.Builder
+	for i, p := range [][2]interface{}{
+		{ "CFStream", true }, { "kSecAttrAccessibleWhenLocked", false }, { "UIWebView", true }, { "RNDecryptor", true },
+		{ "PDKeychainBindings", true }, { "loadRequest", false },
+	}{
+		if CodeAPIs[i].Match(p[0].(string)) != p[1].(bool) {
+			errors.WriteString(fmt.Sprintf("Error in %d test: Expected %t using string %s\n", i, p[1].(bool), p[0].(string)))
+		}
+	}
+	if errors.Len() > 0 {
+		t.Errorf("Found errors:\n: %s", errors.String())
+	}
+}

--- a/ios/ios_rules.go
+++ b/ios/ios_rules.go
@@ -1,0 +1,240 @@
+package ios
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Match func(string) bool
+
+type Level int
+
+const (
+	High Level = iota
+	Warning
+	Info
+	Good
+)
+
+type CodeRule struct {
+	Desc string
+	Match Match
+	Level Level
+	Cvss float32
+	Cwe string
+}
+
+var CodeRules = [...]CodeRule{
+	{
+		"The App may contain banned API(s). These API(s) are insecure and must not be used.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(`strcpy|memcpy|strcat|strncat|strncpy|sprintf|vsprintf|gets`, s)
+			return r
+		},
+		High,
+		2.2,
+		"CWE-676",
+	},
+	{
+		"App allows self signed or invalid SSL certificates. App is vulnerable to MITM attacks.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(
+				`canAuthenticateAgainstProtectionSpace|continueWithoutCredentialForAuthenticationChallenge|` +
+					`kCFStreamSSLAllowsExpiredCertificates|kCFStreamSSLAllowsAnyRoot|` +
+					`kCFStreamSSLAllowsExpiredRoots|validatesSecureCertificate\s*=\s*(no|NO)|` +
+					`allowInvalidCertificates\s*=\s*(YES|yes)`, s)
+			return r
+		},
+		High,
+		7.4,
+		"CWE-295",
+	},
+	{
+		"UIWebView in App ignore SSL errors and accept any SSL Certificate. App is vulnerable to MITM attacks.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(
+				`setAllowsAnyHTTPSCertificate:\s*YES|allowsAnyHTTPSCertificateForHost|` +
+				`loadingUnvalidatedHTTPSPage\s*=\s*(YES|yes)`, s)
+			return r
+		},
+		High,
+		7.4,
+		`CWE-295`,
+	},
+	{
+		"Files may contain hardcoded sensitive informations like usernames, passwords, keys etc.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(
+				`(password\s*=\s*@*\s*['|"].+['|"]\s{0,5})|(pass\s*=\s*@*\s*['|"].+['|"]\s{0,5})|` +
+					`(username\s*=\s*@*\s*['|"].+['|"]\s{0,5})|(secret\s*=\s*@*\s*['|"].+['|"]\s{0,5})|` +
+					`(key\s*=\s*@*\s*['|"].+['|"]\s{0,5})`, strings.ToLower(s))
+			return r
+		},
+		High,
+		7.4,
+		"CWE-312",
+	},
+	{
+		"IP Address disclosure",
+		func(s string) bool {
+			r, _ := regexp.MatchString(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`, s)
+			return r
+		},
+		Warning,
+		4.3,
+		"CWE-200",
+	},
+	{
+		"The App logs information. Sensitive information should never be logged.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(`NSLog|NSAssert|fprintf|Logging`, s)
+			return r
+		},
+		Info,
+		7.5,
+		"CWE-532",
+	},
+	{
+		"This app listens to Clipboard changes. Some malwares also listen to Clipboard changes.",
+		func(s string) bool {
+			r, _ := regexp.MatchString(`UIPasteboardChangedNotification|generalPasteboard]\.string`, s)
+			return r
+		},
+		Warning,
+		0,
+		"",
+	},
+	{
+		"App uses SQLite Database. Sensitive Information should be encrypted.",
+		func(s string) bool {
+			return strings.Contains(s, "sqlite3_exec")
+		},
+		Info,
+		0,
+		"",
+	},
+	{
+		"Untrusted user input to \"NSTemporaryDirectory()\" will result in path traversal vulnerability.",
+		func(s string) bool {
+			return strings.Contains(s, "NSTemporaryDirectory(),")
+		},
+		Warning,
+		7.5,
+		"CWE-22",
+	},
+	{
+		"User input in \"loadHTMLString\" will result in JavaScript Injection.",
+		func(s string) bool {
+			return strings.Contains(s, "loadHTMLString") && strings.Contains(s, "webView")
+		},
+		Warning,
+		8.8,
+		"CWE-95",
+	},
+	{
+		"SFAntiPiracy Jailbreak checks found",
+		func(s string) bool {
+			return strings.Contains(s, "SFAntiPiracy.h") && strings.Contains(s, "SFAntiPiracy") &&
+				strings.Contains(s, "isJailbroken")
+		},
+		Good,
+		0,
+		"",
+	},
+	{
+		"SFAntiPiracy Piracy checks found",
+		func(s string) bool {
+			return strings.Contains(s, "SFAntiPiracy.h") && strings.Contains(s, "SFAntiPiracy") &&
+				strings.Contains(s, "isPirated")
+		},
+		Good,
+		0,
+		"",
+	},
+	{
+		"MD5 is a weak hash known to have hash collisions.",
+		func(s string) bool {
+			return strings.Contains(s, "CommonDigest.h") && strings.Contains(s, "CC_MD5")
+		},
+		High,
+		7.4,
+		"CWE-327",
+	},
+	{
+		"SHA1 is a weak hash known to have hash collisions.",
+		func(s string) bool {
+			return strings.Contains(s, "CommonDigest.h") && strings.Contains(s, "CC_SHA1")
+		},
+		High,
+		7.4,
+		"CWE-327",
+	},
+	{
+		"The App uses ECB mode in Cryptographic encryption algorithm. ECB mode is known to be weak as it " +
+			"results in the same ciphertext for identical blocks of plaintext.",
+		func(s string) bool {
+			return strings.Contains(s, "kCCOptionECBMode") && strings.Contains(s, "kCCAlgorithmAES")
+		},
+		High,
+		5.9,
+		"CWE-327",
+	},
+	{
+		"The App has ant-debugger code using ptrace()",
+		func(s string) bool {
+			return strings.Contains(s, "ptrace_ptr") && strings.Contains(s, "PT_DENY_ATTACH")
+		},
+		Info,
+		0,
+		"",
+	},
+	{
+		"This App has anti-debugger code using Mach Exception Ports.",
+		func(s string) bool {
+			return strings.Contains(s, "mach/mach_init.h") && (strings.Contains(s, "MACH_PORT_VALID") ||
+				strings.Contains(s, "mach_task_self()"))
+		},
+		Info,
+		0,
+		"",
+	},
+	{
+		"This App copies data to clipboard. Sensitive data should not be copied to clipboard as other " +
+			"applications can access it.",
+		func(s string) bool {
+			return strings.Contains(s, "UITextField") && (strings.Contains(s, "@select(cut:)") ||
+				strings.Contains(s, "@select(copy:)"))
+		},
+		Info,
+		0,
+		"",
+	},
+	{
+		"This App may have Jailbreak detection capabilities.",
+		func(s string) bool {
+			for _, m := range []string{
+				"/Applications/Cydia.app", "/Library/MobileSubstrate/MobileSubstrate.dylib",
+				"/usr/sbin/sshd", "/etc/apt", "cydia://", "/var/lib/cydia", "/Applications/FakeCarrier.app",
+				"/Applications/Icy.app", "/Applications/IntelliScreen.app", "/Applications/SBSettings.app",
+				"/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+				"/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+				"/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+				"/etc/ssh/sshd_config", "/private/var/tmp/cydia.log", "/usr/libexec/ssh-keysign",
+				"/Applications/MxTube.app", "/Applications/RockApp.app", "/Applications/WinterBoard.app",
+				"/Applications/blackra1n.app", "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+				"/private/var/lib/apt", "/private/var/lib/cydia", "/private/var/mobile/Library/SBSettings/Themes",
+				"/private/var/stash", "/usr/bin/sshd", "/usr/libexec/sftp-server", "/var/cache/apt",
+				"/var/lib/apt", "/usr/sbin/frida-server", "/usr/bin/cycript", "/usr/local/bin/cycript",
+				"/usr/lib/libcycript.dylib", "frida-server",
+			} {
+				if strings.Contains(s, m) {
+					return true
+				}
+			}
+			return false
+		},
+		Good,
+		0,
+		"",
+	},
+}

--- a/ios/ios_rules.go
+++ b/ios/ios_rules.go
@@ -116,7 +116,7 @@ var CodeRules = [...]CodeRule{
 	{
 		"Untrusted user input to \"NSTemporaryDirectory()\" will result in path traversal vulnerability.",
 		func(s string) bool {
-			return strings.Contains(s, "NSTemporaryDirectory(),")
+			return strings.Contains(s, "NSTemporaryDirectory()")
 		},
 		Warning,
 		7.5,

--- a/ios/ios_rules_test.go
+++ b/ios/ios_rules_test.go
@@ -1,0 +1,1 @@
+package ios

--- a/ios/ios_rules_test.go
+++ b/ios/ios_rules_test.go
@@ -1,1 +1,39 @@
 package ios
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestIosRules(t *testing.T) {
+	var errors strings.Builder
+	for i, p := range  [][2]interface{} {
+		{ "int func(char * dest) { strcpy(src, \"string to copy\") } ", true },
+		{ "const CFStringRef kCFStreamSSLAllowsExpiredCertificates=(CFStringRef)@\"kCFStreamSSLAllowsExpiredCertificates\";", true },
+		{ "setAllowsAnyHTTPSCertificate: YES", true },
+		{ "username = |plaintext|", true },
+		{ "192.189.0.23", true },
+		{ "NSAssert( $(self).CHILDREN().count == self.view.subviews.count, @\" );", true },
+		{ "UIPasteboardChanged", false },
+		{ "sqlite3", false },
+		{ "NSString *path=[NSTemporaryDirectory() stringByAppendingString,@\"bpcities.txt\"];", true },
+		{ "webView.loadHTMLString(contents)", true },
+		{ "//  SFAntiPiracy.h", false },
+		{ "//  SFAntiPiracy.h \n @interface SFAntiPiracy , NSObject\n + (int)isPirated;", true },
+		{ "CommonDigest.h text CC_MD5", true },
+		{ "commondigest.h text CC_SHA1", false },
+		{ "kCCOptionECBMode", false },
+		{ "ptrace_ptr pt_denny_attach", false },
+		{ "#include <mach/mach_init.h>\n static void retainSendRight(mach_port_t port) { if (!MACH_PORT_VALID(port)) return;", true },
+		{ "@select(cut,) || @select(copy,)", false },
+		{ "/etc/ssh/sshd_config", true },
+	} {
+		if CodeRules[i].Match(p[0].(string)) != p[1].(bool) {
+			errors.WriteString(fmt.Sprintf("Error in %d test: Expected %t using string %s\n", i, p[1].(bool), p[0].(string)))
+		}
+	}
+	if errors.Len() > 0 {
+		t.Errorf("Found errors:\n: %s", errors.String())
+	}
+}


### PR DESCRIPTION
This PR creates the ios_apis and ios_rules, used by source_analysis. It diverges a little from the original implementation, so I will explain these changes. 

In the original implementation, a code rule (it's the same for the apis) looked like this:

```python
{
        'desc': 'The App may contain banned API(s). These API(s) are insecure and must not be used.',
        'type': 'regex',
        'regex1': r'strcpy|memcpy|strcat|strncat|strncpy|sprintf|vsprintf|gets',
        'level': 'high',
        'match': 'single_regex',
        'input_case': 'exact',
        'cvss': 2.2,
        'cwe': 'CWE-676'
    }
```

Then a function parsed each object, creating a matching rule from the input_case, match, type and regex1 field (other rules have other fields depending on the type of the match: string1, string2, etc.) to build the match case.

So, for example, in this case, the function that parses the rules would do:

```python
    if rule["input_case"] == "exact":
        tmp_data = data
	if rule["match"] == 'single_regex':
		if re.findall(rule["regex1"], tmp_data):
```

In our case, the same rule looks like this:

```go
{
		Desc: "The App may contain banned API(s). These API(s) are insecure and must not be used.",
		Match: func(s string) bool {
			r, _ := regexp.MatchString(`strcpy|memcpy|strcat|strncat|strncpy|sprintf|vsprintf|gets`, s)
			return r
		},
		Level: High,
		Cvss: 2.2,
		Cwe: "CWE-676",
	},
```

So, the function that parses the rule just have to call the Match function:

```go
if rule.Match(data) {

}
```

This closes #10 and #14 