### PR TITLE
Fix #96 issue

### DIFF
--- a/adapters/input/configuration_test.go
+++ b/adapters/input/configuration_test.go
@@ -90,6 +90,9 @@ func testConfigurationHelper(p string, t *testing.T) {
 }
 
 func TestConfigurationAdapterFromPath(t *testing.T) {
+	f, e := test.FindTest("configuration")
+	assert.NoError(t, e)
+	assert.NoError(t, os.MkdirAll(f, os.ModePerm))
 	for ext, content := range map[string]string{"toml": toml, "json": json, "yaml": yaml} {
 		p, e := test.FindTest("configuration", "vulnscan."+ext)
 		assert.NoError(t, e)


### PR DESCRIPTION
Fixes issue #96 

The adapters/input/configuration_test#TestConfigurationAdapterFromPath function failed when the test/data/configuration folder did not exist. As git does not sync empty folders, this was the situation when pulling the code from the repo. 

This fix creates the folder if it doesn't exist, thus fixing the issue.

## Checklist for PR

- [x] Review & Agree to Code of Conduct
- [x] Review & Agree to Contributing
- [x] Run Vulnerability Scanner unit tests.
- [x] Tests Working on MacOS.
- [x] Make sure the Travis-CI build is passing on your PR.