### PR TITLE
fix issue #98

### DIFF
--- a/framework/filesystem_test.go
+++ b/framework/filesystem_test.go
@@ -39,6 +39,9 @@ func TestWithUnzip(t *testing.T) {
 }
 
 func TestNormalize(t *testing.T) {
+	f, e := test.FindTest("framework", "filesystem", "iVim.app")
+	assert.NoError(t, e)
+	assert.NoError(t, os.MkdirAll(f, os.ModePerm))
 	getPath := func(p string) error {
 		if _, err := os.Stat(filepath.Join(p, "iVim.app")); os.IsNotExist(err) {
 			files, e := ioutil.ReadDir(p)


### PR DESCRIPTION
Closes issue #98

As it happened with issue #96, as git does not sync empty folders, every test that depends on the existance of an empty folder will fail. This is the case of the Normalize test function, that expects an empty folder called iVim.app to exist.

This fix creates the folder if it doesn't exist, thus fixing the issue.
## Checklist for PR

- [x] Review & Agree to Code of Conduct
- [x] Review & Agree to Contributing
- [x] Run Vulnerability Scanner unit tests.
- [x] Tests Working on MacOS.
- [x] Make sure the Travis-CI build is passing on your PR.
