### PR TITLE
fix issue #101

### DIFF
--- a/adapters/input/configuration.go
+++ b/adapters/input/configuration.go
@@ -33,7 +33,8 @@ var configurationToCommandAnalysisMap = map[string]entities.AnalysisCheck{
 func ConfigurationAdapter(command entities.Command, entity *entities.Command, adapter *adapters.AdapterMap) {
 	var configuration = entities.Configuration{}
 	if err := extractConfigurationFile(command, &configuration, adapter); err != nil {
-		_ = adapter.Output.Logger(output.ParseWarning(command, "", "configuration file not found, using default configuration"))
+		_ = adapter.Output.Logger(output.ParseWarning(command, "",
+			"unable to load configuration file: %s, using default configuration", err))
 	} else {
 		loadConfiguration(command, &configuration, entity, adapter)
 	}

--- a/main.go
+++ b/main.go
@@ -57,10 +57,7 @@ var (
 	binaryFlag = func(p *string) cli.StringFlag {
 		return cli.StringFlag{
 			Name: "binary, b",
-			Value: func() string {
-				dir, _ := os.Getwd()
-				return dir
-			}(),
+
 			Usage:       "full path to binary (ipa) file",
 			Destination: p,
 		}
@@ -179,9 +176,14 @@ func getApp() *cli.App {
 			// we will just include two paths in the command entity.
 			if len(binaryPath) > 0 {
 				command.Path = binaryPath
-			} else {
+			} else if len(sourcePath) > 0 {
 				command.Path = sourcePath
 				command.Source = true
+			} else if len(command.Path) == 0 {
+				command.Path = func() string {
+					dir, _ := os.Getwd()
+					return dir
+				}()
 			}
 			if len(toolsFolder) > 0 {
 				command.Tools = toolsFolder


### PR DESCRIPTION
Closes issue #101 

The binary path flag overwrites the one set on the configuration file. As we were passing a default value to the binary path flag, this was always the case, so setting a binary path in the configuration file always failed. 

This PR fixes that, setting the default binary path only after checking the user has not passed any path using flags or configuration files. 

It also add a better warning message if the configuration file loading fails, printing the error it was found (this error can either be that no file was found or that the file was malformed for some reason, instead of assuming it was not found. 


## Checklist for PR

- [x] Review & Agree to Code of Conduct
- [x] Review & Agree to Contributing
- [x] Run Vulnerability Scanner unit tests.
- [x] Tests Working on MacOS.
- [x] Make sure the Travis-CI build is passing on your PR.
