### PR TITLE
Closes #113

### DIFF
--- a/adapters/services/malware_domains_test.go
+++ b/adapters/services/malware_domains_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package services
 
 import (

--- a/adapters/services/virus_total_test.go
+++ b/adapters/services/virus_total_test.go
@@ -12,8 +12,13 @@ import (
 
 func TestVirusTotalAdapter(t *testing.T) {
 	mainFolder, _ := test.FindMainFolder()
-	assert.NoError(t, godotenv.Load(filepath.Join(mainFolder, ".env")))
+	if err := godotenv.Load(filepath.Join(mainFolder, ".env")); err != nil {
+		return
+	}
 	apiKey := os.Getenv("VIRUS_TOTAL_API_KEY")
+	if len(apiKey) == 0 {
+		return
+	}
 	assert.NotEmpty(t, apiKey)
 	path, _ := test.FindTest("adapters", "services", "binary.ipa")
 	var (

--- a/adapters/services/virus_total_test.go
+++ b/adapters/services/virus_total_test.go
@@ -1,24 +1,17 @@
+// +build integration
+
 package services
 
 import (
-	"github.com/joho/godotenv"
 	"github.com/simplycubed/vulnscan/entities"
 	"github.com/simplycubed/vulnscan/test"
 	"github.com/stretchr/testify/assert"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
 func TestVirusTotalAdapter(t *testing.T) {
-	mainFolder, _ := test.FindMainFolder()
-	if err := godotenv.Load(filepath.Join(mainFolder, ".env")); err != nil {
-		return
-	}
 	apiKey := os.Getenv("VIRUS_TOTAL_API_KEY")
-	if len(apiKey) == 0 {
-		return
-	}
 	assert.NotEmpty(t, apiKey)
 	path, _ := test.FindTest("adapters", "services", "binary.ipa")
 	var (

--- a/usecases/static/static_analysis_test.go
+++ b/usecases/static/static_analysis_test.go
@@ -19,7 +19,9 @@ func binaryIpaTestAdapter(command entities.Command, entity entities.Entity) erro
 		assert.NotEmpty(command.T, ent.Binary.Results)
 		assert.NotEmpty(command.T, ent.Binary.Libraries)
 		assert.NotEmpty(command.T, ent.Store.Results)
-		assert.NotEmpty(command.T, ent.Virus.Report.Scans)
+		if len(command.VirusTotalKey) > 0 {
+			assert.NotEmpty(command.T, ent.Virus.Report.Scans)
+		}
 		return nil
 	}
 	return nil
@@ -31,7 +33,9 @@ func notAppStoreTestAdapter(command entities.Command, entity entities.Entity) er
 		assert.NotEmpty(command.T, ent.Plist.Xml)
 		assert.NotEmpty(command.T, ent.Binary.Results)
 		assert.NotEmpty(command.T, ent.Binary.Libraries)
-		assert.NotEmpty(command.T, ent.Virus.Report.Scans)
+		if len(command.VirusTotalKey) > 0 {
+			assert.NotEmpty(command.T, ent.Virus.Report.Scans)
+		}
 		return nil
 	}
 	return nil
@@ -45,7 +49,9 @@ func doubleDviaTestAdapter(command entities.Command, entity entities.Entity) err
 		assert.NotEmpty(command.T, ent.Binary.Libraries)
 		assert.NotEmpty(command.T, ent.Code.Codes)
 		assert.NotEmpty(command.T, ent.Code.Apis)
-		assert.NotEmpty(command.T, ent.Virus.Report.Scans)
+		if len(command.VirusTotalKey) > 0 {
+			assert.NotEmpty(command.T, ent.Virus.Report.Scans)
+		}
 		return nil
 	}
 	return nil

--- a/usecases/static/static_analysis_test.go
+++ b/usecases/static/static_analysis_test.go
@@ -53,7 +53,7 @@ func doubleDviaTestAdapter(command entities.Command, entity entities.Entity) err
 
 func TestAnalysis(t *testing.T) {
 	mainFolder, _ := test.FindMainFolder()
-	assert.NoError(t, godotenv.Load(mainFolder+string(os.PathSeparator)+".env"))
+	_ = godotenv.Load(mainFolder + string(os.PathSeparator) + ".env")
 	var testMap = map[string]func(command entities.Command, entity entities.Entity) error{}
 	for k, v := range map[string]func(command entities.Command, entity entities.Entity) error{
 		"binary.ipa":        binaryIpaTestAdapter,
@@ -92,7 +92,7 @@ func TestAnalysis(t *testing.T) {
 
 func TestDoubleAnalysis(t *testing.T) {
 	mainFolder, _ := test.FindMainFolder()
-	assert.NoError(t, godotenv.Load(mainFolder+string(os.PathSeparator)+".env"))
+	_ = godotenv.Load(mainFolder + string(os.PathSeparator) + ".env")
 	var testMap = map[[2]string]func(command entities.Command, entity entities.Entity) error{}
 	for k, v := range map[string]func(command entities.Command, entity entities.Entity) error{
 		"DVIA.ipa|DVIA.zip":             doubleDviaTestAdapter,


### PR DESCRIPTION
This PR closes the #113 issue, the #112 issue and the #83 issue.

Regarding #113, I believe the problem was that the data submodule was referencing the vulnscan_testfiles repo, that was in the previous commit.

I have tested and all test pass when cloning my own version of the repo. 

About #112, I just added a check int the static analysis test to see if the virus total key have been set in the .env file. If not, the static analysis test ignores the virus output. 

Finally, the proposed solution to close #83 is added to the services tests. For running all test, a -tags=integration flag must be passed to go test. The services tests still depend on the virus total key to be present, but they are skipped by default. 

## Checklist for PR

- [x] Review & Agree to Code of Conduct
- [x] Review & Agree to Contributing
- [x] Run Vulnerability Scanner unit tests.
- [x] Tests Working on MacOS.
- [x] Make sure the Travis-CI build is passing on your PR.
