### PR TITLE
Update travis config, codacy is not getting coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,4 @@ script:
   - go build
   - go test
   - goverage -v -coverprofile=coverage.out ./...
-
-after_success:
-  - godacov -t $CODACY_TOKEN -r ./coverage.out -c `git rev-parse HEAD`
-
+  - godacov -t $CODACY_TOKEN -r ./coverage.out -c $TRAVIS_COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ script:
   - go build
   - go test
   - goverage -v -coverprofile=coverage.out ./...
+
+after_success:
   - godacov -t $CODACY_TOKEN -r ./coverage.out -c $TRAVIS_COMMIT


### PR DESCRIPTION
<!-- Thank you for your contribution to Vulnerability Scanner! -->

# Describe the Pull Request

Updating travis config, codacy is not getting coverage reports.

## Checklist for PR

- [x] Review & Agree to Code of Conduct
- [x] Review & Agree to Contributing
- [x] Run Vulnerability Scanner unit tests.
- [x] Tests Working on MacOS.
- [ ] Make sure the Travis-CI build is passing on your PR.
